### PR TITLE
Add keyword input

### DIFF
--- a/src/ColorToolApp.tsx
+++ b/src/ColorToolApp.tsx
@@ -5,6 +5,7 @@ import { ColorToolContextProps, ColorToolContext } from '~/ColorToolContext';
 import { HexInput } from '~/color/controls/inputs/HexInput';
 import { MultiInput } from '~/color/controls/inputs/MultiInput';
 import { ColorInput } from '~/color/controls/inputs/ColorInput';
+import { KeywordInput } from '~/color/controls/inputs/KeywordInput';
 
 import { HslaModifier } from '~/color/controls/modifiers/HslaModifier';
 
@@ -14,16 +15,18 @@ export const ColorToolApp = () => {
   // Default to empty inputs for RGBA / HSLA. Most of the time we want to
   // treat the inputs as numbers. Using a value is required to let React know
   // that the inputs are controlled.
-  const [{ hex, rgba, hsla }, dispatch] = useReducer(colorReducer, {
+  const [{ hex, rgba, hsla, keyword }, dispatch] = useReducer(colorReducer, {
     hex: '',
     rgba: ['', '', '', ''],
     hsla: ['', '', '', ''],
+    keyword: '',
   });
 
   const state: ColorToolContextProps = {
     hex,
     rgba,
     hsla,
+    keyword,
 
     dispatch,
   };
@@ -34,6 +37,7 @@ export const ColorToolApp = () => {
         <HexInput />
         <MultiInput parser="rgba" label="RGB(A): " />
         <MultiInput parser="hsla" label="HSL(A): " />
+        <KeywordInput />
         <ColorInput />
         <div
           className="color-display"

--- a/src/ColorToolContext.ts
+++ b/src/ColorToolContext.ts
@@ -9,6 +9,7 @@ export interface ColorToolContextProps {
   hex: string;
   rgba: number[] | string[];
   hsla: number[] | string[];
+  keyword: string;
 
   dispatch: Dispatch<ColorToolAction>;
 }

--- a/src/color/actions.ts
+++ b/src/color/actions.ts
@@ -1,6 +1,7 @@
 import { createStandardAction, createAction } from 'typesafe-actions';
 
 export const updateHex = createStandardAction('UPDATE_HEX')<string>();
+export const updateKeyword = createStandardAction('UPDATE_KEYWORD')<string>();
 export const updateMulti = createAction(
   'UPDATE_MULTI',
   resolve => (parser, value) => resolve({ parser, value }),

--- a/src/color/controls/inputs/KeywordInput.tsx
+++ b/src/color/controls/inputs/KeywordInput.tsx
@@ -24,7 +24,7 @@ export const KeywordInput = () => {
         onChange={onChange}
         style={{
           width: 230,
-          backgroundColor: /^\w*$/.test(keyword) ? '' : '#ffb8c2',
+          backgroundColor: /^[a-z]*$/.test(keyword) ? '' : '#ffb8c2',
           color: parse(keyword).hex ? '' : '#9FA9A3',
         }}
       />

--- a/src/color/controls/inputs/KeywordInput.tsx
+++ b/src/color/controls/inputs/KeywordInput.tsx
@@ -1,0 +1,34 @@
+import React, { useContext, useRef } from 'react';
+import parse from 'parse-color';
+
+import { ColorToolContext } from '~/ColorToolContext';
+import { updateKeyword } from '~/color/actions';
+import { CopyToClipboardButton } from './CopyToClipboardButton';
+
+export const KeywordInput = () => {
+  const { keyword, dispatch } = useContext(ColorToolContext);
+  const input = useRef(null);
+
+  const onChange = ({ target: { value } }) => {
+    dispatch(updateKeyword(value));
+  };
+
+  return (
+    <label>
+      <span className="input-label">Keyword:</span>
+      <input
+        className="color-input"
+        type="text"
+        ref={input}
+        value={keyword}
+        onChange={onChange}
+        style={{
+          width: 230,
+          backgroundColor: /^\w*$/.test(keyword) ? '' : '#ffb8c2',
+          color: parse(keyword).hex ? '' : '#9FA9A3',
+        }}
+      />
+      <CopyToClipboardButton value={keyword} />
+    </label>
+  );
+};

--- a/src/color/reducer.ts
+++ b/src/color/reducer.ts
@@ -10,6 +10,7 @@ export type ColorToolState = Pick<
   Exclude<keyof ColorToolContextProps, 'dispatch'>
 >;
 
+// tslint:disable-next-line:cognitive-complexity
 export function colorReducer(
   state: ColorToolState,
   action: ColorToolAction,
@@ -19,10 +20,11 @@ export function colorReducer(
       const { payload } = action;
       // Valid and complete hex color code provided by the payload
       if (payload && /^#(\d|[a-f]){6}$/i.test(payload)) {
-        const { rgba, hsla } = parse(payload);
+        const { rgba, hsla, keyword } = parse(payload);
         return {
           rgba,
           hsla,
+          keyword: keyword ? keyword : state.keyword,
           hex: payload,
         };
       }
@@ -32,10 +34,30 @@ export function colorReducer(
       };
     }
 
+    case getType(actions.updateKeyword): {
+      const { payload } = action;
+      const { rgba, hsla, hex, keyword } = parse(payload);
+      // keyword comes back no matter what, so we check hex as well to make sure
+      // a valid color was provided
+      if (hex && keyword && /[\w-]+/.test(keyword)) {
+        return {
+          rgba,
+          hsla,
+          hex,
+          keyword: payload,
+        };
+      }
+
+      return {
+        ...state,
+        keyword: payload,
+      };
+    }
+
     case getType(actions.updateMulti): {
       const { parser, value } = action.payload;
       if (value.every(isValidNumber)) {
-        const { hex, rgba, hsla, [parser]: color } = parseAsClamped(
+        const { hex, rgba, hsla, keyword, [parser]: color } = parseAsClamped(
           parser,
           value,
         );
@@ -45,6 +67,7 @@ export function colorReducer(
             hex,
             hsla,
             rgba,
+            keyword: keyword ? keyword : state.keyword,
             [parser]: color,
           };
         }

--- a/src/color/reducer.ts
+++ b/src/color/reducer.ts
@@ -24,7 +24,7 @@ export function colorReducer(
         return {
           rgba,
           hsla,
-          keyword: keyword ? keyword : state.keyword,
+          keyword: keyword ? keyword : '',
           hex: payload,
         };
       }
@@ -67,7 +67,7 @@ export function colorReducer(
             hex,
             hsla,
             rgba,
-            keyword: keyword ? keyword : state.keyword,
+            keyword: keyword ? keyword : '',
             [parser]: color,
           };
         }

--- a/src/color/reducer.ts
+++ b/src/color/reducer.ts
@@ -39,7 +39,7 @@ export function colorReducer(
       const { rgba, hsla, hex, keyword } = parse(payload);
       // keyword comes back no matter what, so we check hex as well to make sure
       // a valid color was provided
-      if (hex && keyword && /[\w-]+/.test(keyword)) {
+      if (hex && keyword && /^[a-z]+$/.test(keyword)) {
         return {
           rgba,
           hsla,

--- a/src/style.css
+++ b/src/style.css
@@ -9,7 +9,7 @@ body {
 }
 
 .input-label {
-  width: 100px;
+  width: 120px;
   display: inline-block;
 }
 


### PR DESCRIPTION
This adds a "Keyword" input alongside the other color tool inputs. This works both ways -- typing in a valid keyword updates all colors, and updating a color that has a valid corresponding keyword does the reverse.