### PR TITLE
Alpha value and hex cleanup

### DIFF
--- a/src/ColorToolApp.tsx
+++ b/src/ColorToolApp.tsx
@@ -48,12 +48,14 @@ export const ColorToolApp = () => {
         <MultiInput parser="hsla" label="HSL(A): " />
         <KeywordInput />
         <ColorInput />
-        <div
-          className="color-display"
-          style={{
-            backgroundColor: `rgba(${rgba.join()})`,
-          }}
-        />
+        <div className="color-display-container" >
+          <div
+            className="color-display"
+            style={{
+              backgroundColor: `rgba(${rgba.join()})`,
+            }}
+          />
+        </div>
 
         <section aria-label="hsla color modifiers" className="color-modifiers">
           <div>

--- a/src/ColorToolContext.ts
+++ b/src/ColorToolContext.ts
@@ -13,10 +13,10 @@ export interface ColorToolContextProps {
   hex: string;
 
   // RGBA representation [0-255, 0-255, 0-255, 0-1]
-  rgba: number[] | string[];
+  rgba: (number | string)[];
 
   // HSLA representation [0-359, 0-100, 0-100, 0-1]
-  hsla: number[] | string[];
+  hsla: (number | string)[];
 
   // Keyword representation
   keyword: string;

--- a/src/color-check-util.ts
+++ b/src/color-check-util.ts
@@ -8,9 +8,7 @@ import parse from 'parse-color';
  * `1`, but we only want to parse strictly numeric values and pass others through
  */
 export function isValidNumber(value: string | number) {
-  return (
-    Number.isFinite(+value) || /(^-?\d+(\.\d+)?$)|^\.\d+$/.test(value as string)
-  );
+  return /(^-?\d+(\.\d+)?$)|^\.\d+$/.test(value as string);
 }
 
 export function clampMultiColorValue(

--- a/src/color-check-util.ts
+++ b/src/color-check-util.ts
@@ -53,7 +53,7 @@ export function parseAsClamped(parser: 'hsla' | 'rgba', values: number[]) {
 // Determine whether the input is valid. An empty string or any partial hex
 // value will be valid.
 export function isValidHex(hexValue: string) {
-  return !hexValue || /^#[a-f0-9]*$/i.test(hexValue);
+  return !hexValue || /^#[a-f0-9]{1,6}$/i.test(hexValue);
 }
 
 // Determine whether the input is valid. All keywords are pure lowercase alpha.

--- a/src/color/reducer.ts
+++ b/src/color/reducer.ts
@@ -25,13 +25,30 @@ export const createStateFromParsedColor = ({
   hsla,
   rgba,
   keyword,
-}: Color): ColorToolState => ({
+}: Partial<ColorToolState>): ColorToolState => ({
   hex,
   hsla,
   rgba,
   keyword: keyword ? keyword : '',
   hasKeyword: !!keyword,
 });
+
+export const retainAlphas = (
+  oldColor: ColorToolState,
+  newColor: Color,
+): Partial<ColorToolState> => {
+  return {
+    ...newColor,
+    hsla: [
+      ...newColor.hsla.slice(0, 3),
+      (oldColor.hsla && oldColor.hsla[3]) || 1,
+    ] as number[],
+    rgba: [
+      ...newColor.rgba.slice(0, 3),
+      (oldColor.rgba && oldColor.rgba[3]) || 1,
+    ] as number[],
+  };
+};
 
 export function colorReducer(
   state: ColorToolState,
@@ -43,7 +60,9 @@ export function colorReducer(
       let nextState = {};
       // Valid and complete hex color code provided by the payload
       if (payload && /^#[a-f0-9]{6}$/i.test(payload)) {
-        nextState = createStateFromParsedColor(parse(payload));
+        nextState = createStateFromParsedColor(
+          retainAlphas(state, parse(payload)),
+        );
       }
 
       return {
@@ -60,7 +79,9 @@ export function colorReducer(
       // keyword comes back no matter what, so we check hex as well to make sure
       // a valid color was provided
       if (hex && keyword && isValidKeyword(keyword)) {
-        nextState = createStateFromParsedColor({ ...parsed, keyword, hex });
+        nextState = createStateFromParsedColor(
+          retainAlphas(state, { ...parsed, keyword, hex }),
+        );
       }
 
       return {

--- a/src/color/reducer.ts
+++ b/src/color/reducer.ts
@@ -33,6 +33,11 @@ export const createStateFromParsedColor = ({
   hasKeyword: !!keyword,
 });
 
+/**
+ * When updating hex or keyword, the parsed color hsla/rgba always have an
+ * alpha of 1. We want to use the updated color value but retain the existing
+ * alpha value that may have been modified (if it exists).
+ */
 export const retainAlphas = (
   oldColor: ColorToolState,
   newColor: Color,
@@ -42,11 +47,11 @@ export const retainAlphas = (
     hsla: [
       ...newColor.hsla.slice(0, 3),
       (oldColor.hsla && oldColor.hsla[3]) || 1,
-    ] as number[],
+    ],
     rgba: [
       ...newColor.rgba.slice(0, 3),
       (oldColor.rgba && oldColor.rgba[3]) || 1,
-    ] as number[],
+    ],
   };
 };
 

--- a/src/style.css
+++ b/src/style.css
@@ -7,11 +7,18 @@ body {
   margin-bottom: 20px;
 }
 
-.color-display {
+.color-display-container {
   margin-bottom: 25px;
   margin-left: 25px;
   width: 100px;
   height: 100px;
   border: 1px solid black;
   transition: background-color 1s;
+  background: linear-gradient(45deg, currentColor 25%,  transparent 25%, transparent 75%, currentColor 75%, currentColor),
+            linear-gradient(45deg, currentColor 25%,  transparent  25%,  transparent 75%, currentColor 75%, currentColor) 10px 10px;
+  background-size: 20px 20px;
+}
+
+.color-display {
+  height: 100%;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "ts-config-mobiquity-react-native",
   "compilerOptions": {
+    "target": "es5",
     "baseUrl": "./src",
     "paths": {
       "~*": ["./*"]


### PR DESCRIPTION
* Use transparency indicator for color display shamelessly ripped from https://contrast-ratio.com/
* Update `isValidNumber` check to be more strict. This should not allow strings written as `0.`, but `Number.isNumber(+'0.')` is valid. This check is unnecessary since all valid numbers cast to strings should pass this check (for our purposes, anyway)
* Update hex check to be invalid for more than 6 digits (hexits?)